### PR TITLE
Add configurable leadbot with CSV export and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,22 @@ After installation, you can start using the Real Estate Leadbot. Here’s how:
 
 ## Configuration
 
-To customize the bot for your needs, you can modify the configuration file. Here’s how:
+The bot now uses a `config.json` file for all of its settings, making it simple
+to tweak regions, price spread and more. Follow these steps to customise it:
 
 1. **Open the Configuration File**:  
    Locate `config.json` in the project directory.
 
 2. **Edit the Settings**:  
    Adjust the settings as needed:
-   - **Email Settings**: Configure your SendGrid API key and email address.
-   - **Scraping Settings**: Set parameters for the scraping process, such as the location and property types.
+   - **Email Settings**: Configure your SendGrid API key and email addresses.
+   - **Regions**: Provide a comma separated list of ZIP codes to search.
+   - **Discount Threshold**: Percentage under the average price that qualifies a listing as a lead.
+   - **Output CSV**: File path where scraped leads will be written.
 
-3. **Save Changes**:  
-   Save the configuration file before running the bot again.
+3. **Save Changes**:
+   Save the configuration file before running the bot again or use the optional
+   `leadbot_ui.py` interface to edit and run the bot with a graphical window.
 
 ## Contributing
 

--- a/autopilot_leadbot.py
+++ b/autopilot_leadbot.py
@@ -1,35 +1,58 @@
+import csv
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
-from zillow_scraper import generate_urls, scrape_zillow
 
-print("[+] Scraping Zillow for test data...")
+from config import load_config
+from zillow_scraper import generate_urls, scrape_zillow, filter_under_market
 
-leads = []
-for url in generate_urls():
-    leads.extend(scrape_zillow(url))
 
-print(f"[+] Scraped {len(leads)} leads.")
+def main():
+    config = load_config()
+    print(f"[+] Scraping Zillow for regions: {config['regions']}")
 
-html_content = "<h3>Test Zillow FSBO Leads</h3><ul>"
-for lead in leads[:5]:
-    html_content += f'''
-    <li><strong>{lead["price"]}</strong> – {lead["address"]}<br>
-    <a href="{lead["link"]}">View Listing</a><br>
-    <small>{lead["timestamp"]}</small></li><br>'''
-html_content += "</ul>"
+    leads = []
+    for url in generate_urls(config['regions']):
+        leads.extend(scrape_zillow(url))
 
-print("[+] Sending email via SendGrid API...")
+    print(f"[+] Scraped {len(leads)} total listings.")
 
-message = Mail(
-    from_email='you@example.com',
-    to_emails='you@example.com',
-    subject='Test Real Estate Leads',
-    html_content=html_content
-)
+    filtered = filter_under_market(leads, config['discount_threshold'])
+    print(
+        f"[+] {len(filtered)} listings under market by {config['discount_threshold']*100}%"
+    )
 
-try:
-    sg = SendGridAPIClient('your_api_key_here')
-    response = sg.send(message)
-    print("✅ Email sent! Status code:", response.status_code)
-except Exception as e:
-    print("❌ Failed to send email:", e)
+    with open(config['output_csv'], 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['price', 'address', 'link', 'timestamp'])
+        writer.writeheader()
+        writer.writerows(filtered)
+
+    print(f"[+] Saved leads to {config['output_csv']}")
+
+    html_content = "<h3>Zillow FSBO Leads</h3><ul>"
+    for lead in filtered[:10]:
+        html_content += (
+            f"<li><strong>${lead['price']:,.0f}</strong> – {lead['address']}<br>"
+            f"<a href='{lead['link']}'>View Listing</a><br>"
+            f"<small>{lead['timestamp']}</small></li><br>"
+        )
+    html_content += "</ul>"
+
+    print("[+] Sending email via SendGrid API...")
+
+    message = Mail(
+        from_email=config['from_email'],
+        to_emails=config['to_email'],
+        subject='Real Estate Leads',
+        html_content=html_content,
+    )
+
+    try:
+        sg = SendGridAPIClient(config['sendgrid_api_key'])
+        response = sg.send(message)
+        print("✅ Email sent! Status code:", response.status_code)
+    except Exception as e:
+        print("❌ Failed to send email:", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+    "sendgrid_api_key": "your_api_key_here",
+    "from_email": "you@example.com",
+    "to_email": "you@example.com",
+    "regions": ["30058"],
+    "discount_threshold": 0.1,
+    "output_csv": "leads.csv"
+}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,25 @@
+import json
+
+DEFAULT_CONFIG = {
+    "sendgrid_api_key": "your_api_key_here",
+    "from_email": "you@example.com",
+    "to_email": "you@example.com",
+    "regions": ["30058"],
+    "discount_threshold": 0.1,
+    "output_csv": "leads.csv"
+}
+
+
+def load_config(path="config.json"):
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        data = DEFAULT_CONFIG
+        save_config(data, path)
+    return data
+
+
+def save_config(data, path="config.json"):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=4)

--- a/leadbot_ui.py
+++ b/leadbot_ui.py
@@ -1,0 +1,48 @@
+import threading
+import tkinter as tk
+from tkinter import messagebox
+
+import autopilot_leadbot
+from config import load_config, save_config
+
+
+class LeadbotUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Leadbot Configuration")
+        self.config_data = load_config()
+        self.entries = {}
+        row = 0
+        for key, value in self.config_data.items():
+            tk.Label(self, text=key).grid(row=row, column=0, sticky="e")
+            entry = tk.Entry(self, width=40)
+            if isinstance(value, list):
+                entry.insert(0, ",".join(value))
+            else:
+                entry.insert(0, str(value))
+            entry.grid(row=row, column=1, padx=5, pady=2)
+            self.entries[key] = entry
+            row += 1
+        tk.Button(self, text="Save", command=self.save).grid(row=row, column=0, pady=5)
+        tk.Button(self, text="Run", command=self.run_bot).grid(row=row, column=1, pady=5)
+
+    def save(self):
+        for key, entry in self.entries.items():
+            val = entry.get()
+            if key == "regions":
+                val = [v.strip() for v in val.split(",") if v.strip()]
+            elif key == "discount_threshold":
+                val = float(val)
+            self.config_data[key] = val
+        save_config(self.config_data)
+        messagebox.showinfo("Leadbot", "Configuration saved")
+
+    def run_bot(self):
+        self.save()
+        threading.Thread(target=autopilot_leadbot.main, daemon=True).start()
+        messagebox.showinfo("Leadbot", "Leadbot started in background")
+
+
+if __name__ == "__main__":
+    app = LeadbotUI()
+    app.mainloop()

--- a/run_leadbot.sh
+++ b/run_leadbot.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
-cd /root/leadbots
-source venv/bin/activate
-python autopilot_leadbot.py
+# Simple helper script to run the leadbot using the virtual environment if
+# available.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -d "$DIR/venv" ]; then
+    source "$DIR/venv/bin/activate"
+fi
+python "$DIR/autopilot_leadbot.py"

--- a/zillow_scraper.py
+++ b/zillow_scraper.py
@@ -2,16 +2,26 @@ import requests
 from bs4 import BeautifulSoup
 from datetime import datetime
 
-SENDGRID_API_KEY = "your_api_key_here"
-TO_EMAIL = "you@example.com"
-FROM_EMAIL = "you@example.com"
-ZIP_CODES = ["30058"]
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
-def generate_urls():
-    return [f"https://www.zillow.com/homes/fsbo/{zip_code}_rb/" for zip_code in ZIP_CODES]
+def generate_urls(regions):
+    """Generate Zillow FSBO URLs for a list of region codes."""
+    return [f"https://www.zillow.com/homes/fsbo/{code}_rb/" for code in regions]
+
+def parse_price(text):
+    text = (
+        text.replace("$", "")
+        .replace(",", "")
+        .split()[0]
+    )
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
 
 def scrape_zillow(url):
+    """Scrape a single Zillow FSBO page."""
     response = requests.get(url, headers=HEADERS)
     soup = BeautifulSoup(response.text, "html.parser")
     listings = soup.select("article")
@@ -21,10 +31,22 @@ def scrape_zillow(url):
         price = listing.find("span", {"data-test": "property-card-price"})
         address = listing.find("address")
         if link and price and address:
-            results.append({
-                "link": "https://www.zillow.com" + link["href"],
-                "price": price.get_text(strip=True),
-                "address": address.get_text(strip=True),
-                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            })
+            results.append(
+                {
+                    "link": "https://www.zillow.com" + link["href"],
+                    "price": parse_price(price.get_text(strip=True)),
+                    "address": address.get_text(strip=True),
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                }
+            )
     return results
+
+
+def filter_under_market(leads, discount):
+    """Return listings priced below the average by a given discount."""
+    prices = [lead["price"] for lead in leads if isinstance(lead.get("price"), int)]
+    if not prices:
+        return []
+    avg_price = sum(prices) / len(prices)
+    threshold = avg_price * (1 - discount)
+    return [lead for lead in leads if isinstance(lead.get("price"), int) and lead["price"] <= threshold]


### PR DESCRIPTION
## Summary
- support configuration via `config.json`
- add helper module `config.py`
- rework Zillow scraper to use config and add filtering
- create UI for editing the config and launching the bot
- extend `autopilot_leadbot.py` to save CSV results
- update run script and README

## Testing
- `python -m py_compile autopilot_leadbot.py zillow_scraper.py leadbot_ui.py config.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python autopilot_leadbot.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862ccc34d4083318e8e6c1fe4d44f2c