### PR TITLE
Add Mailjet email integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can find the latest releases of the Real Estate Leadbot [here](https://githu
 - **Automated Scraping**: Automatically gathers FSBO listings from Zillow so you always have the latest leads.
 - **Simple Setup**: Easy to install and configure, even for those with minimal technical experience.
 - **Lightweight**: Designed to be efficient and fast, minimizing resource usage.
+- **Mailjet Integration**: Optionally email scraped leads using Mailjet.
 
 ## Installation
 
@@ -80,6 +81,10 @@ to tweak regions, price spread and more. Follow these steps to customise it:
    - **Regions**: Provide a comma separated list of ZIP codes to search.
    - **Discount Threshold**: Percentage under the average price that qualifies a listing as a lead.
    - **Output CSV**: File path where scraped leads will be written.
+   - **Mailjet API Key**: Your Mailjet API key for sending email notifications.
+   - **Mailjet API Secret**: Your Mailjet API secret.
+   - **Mailjet Sender**: The email address Mailjet should send from.
+   - **Mailjet Recipient**: Email address to receive scraped leads.
 
 3. **Save Changes**:
    Save the configuration file before running the bot again or use the graphical

--- a/autopilot_leadbot.py
+++ b/autopilot_leadbot.py
@@ -2,6 +2,7 @@ import csv
 
 from config import load_config
 from zillow_scraper import generate_urls, scrape_zillow, filter_under_market
+from mailjet_utils import send_leads_via_mailjet
 
 
 def main():
@@ -25,6 +26,8 @@ def main():
         writer.writerows(filtered)
 
     print(f"[+] Saved leads to {config['output_csv']}")
+
+    send_leads_via_mailjet(filtered, config)
 
 
     # Display the first few leads for convenience

--- a/config.json
+++ b/config.json
@@ -1,5 +1,9 @@
 {
     "regions": ["30058"],
     "discount_threshold": 0.1,
-    "output_csv": "leads.csv"
+    "output_csv": "leads.csv",
+    "mailjet_api_key": "",
+    "mailjet_api_secret": "",
+    "mailjet_sender": "",
+    "mailjet_recipient": ""
 }

--- a/config.py
+++ b/config.py
@@ -4,6 +4,10 @@ DEFAULT_CONFIG = {
     "regions": ["30058"],
     "discount_threshold": 0.1,
     "output_csv": "leads.csv",
+    "mailjet_api_key": "",
+    "mailjet_api_secret": "",
+    "mailjet_sender": "",
+    "mailjet_recipient": "",
 }
 
 
@@ -12,7 +16,16 @@ def load_config(path="config.json"):
         with open(path, "r") as f:
             data = json.load(f)
     except FileNotFoundError:
-        data = DEFAULT_CONFIG
+        data = DEFAULT_CONFIG.copy()
+        save_config(data, path)
+        return data
+
+    updated = False
+    for key, value in DEFAULT_CONFIG.items():
+        if key not in data:
+            data[key] = value
+            updated = True
+    if updated:
         save_config(data, path)
     return data
 

--- a/mailjet_utils.py
+++ b/mailjet_utils.py
@@ -1,0 +1,39 @@
+from mailjet_rest import Client
+
+
+def send_leads_via_mailjet(leads, config):
+    required = [
+        "mailjet_api_key",
+        "mailjet_api_secret",
+        "mailjet_sender",
+        "mailjet_recipient",
+    ]
+    if not all(config.get(k) for k in required):
+        print("[-] Mailjet configuration incomplete, skipping email.")
+        return
+
+    if not leads:
+        print("[-] No leads to email.")
+        return
+
+    mailjet = Client(auth=(config["mailjet_api_key"], config["mailjet_api_secret"]), version="v3.1")
+    body = "\n".join(
+        f"${lead['price']:,.0f} {lead['address']} ({lead['link']})" for lead in leads
+    )
+
+    data = {
+        "Messages": [
+            {
+                "From": {"Email": config["mailjet_sender"], "Name": "Leadbot"},
+                "To": [{"Email": config["mailjet_recipient"]}],
+                "Subject": "New Real Estate Leads",
+                "TextPart": body,
+            }
+        ]
+    }
+
+    try:
+        result = mailjet.send.create(data=data)
+        print(f"[+] Sent email via Mailjet with status {result.status_code}")
+    except Exception as e:
+        print(f"[-] Failed to send email via Mailjet: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+mailjet-rest


### PR DESCRIPTION
## Summary
- integrate Mailjet support by adding `mailjet_utils.py`
- send scraped leads via Mailjet in `autopilot_leadbot.py`
- store Mailjet credentials in config
- update default config file
- document Mailjet setup in README
- update dependencies

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862d0dc275c83319f254e60598eb63b